### PR TITLE
Server: SQLite database layer for rooms and messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.db
+.agent.lock
+bun.lock

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[install]
+peer = false

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "agentmeets",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@agentmeets/server",
+  "version": "0.1.0",
+  "type": "module",
+  "dependencies": {
+    "@agentmeets/shared": "workspace:*",
+    "nanoid": "^5.0.9"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "bun-types": "latest"
+  }
+}

--- a/packages/server/src/db/db.test.ts
+++ b/packages/server/src/db/db.test.ts
@@ -1,0 +1,256 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { initializeSchema } from "./schema.js";
+import {
+  createRoom,
+  getRoom,
+  joinRoom,
+  closeRoom,
+  expireRoom,
+  getRoomByToken,
+} from "./rooms.js";
+import { saveMessage, getMessages, getPendingMessages } from "./messages.js";
+import { createDatabase, generateRoomId, generateToken } from "./index.js";
+
+let db: Database;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  initializeSchema(db);
+});
+
+describe("schema", () => {
+  test("creates tables on initialization", () => {
+    const tables = db
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type='table' ORDER BY name`,
+      )
+      .all() as { name: string }[];
+    const names = tables.map((t) => t.name);
+    expect(names).toContain("rooms");
+    expect(names).toContain("messages");
+  });
+
+  test("creates index on messages.room_id", () => {
+    const indexes = db
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='messages'`,
+      )
+      .all() as { name: string }[];
+    const names = indexes.map((i) => i.name);
+    expect(names).toContain("idx_messages_room");
+  });
+});
+
+describe("createDatabase", () => {
+  test("creates a working database with schema", () => {
+    const testDb = createDatabase(":memory:");
+    const room = createRoom(testDb, "TEST01", "token-host");
+    expect(room.id).toBe("TEST01");
+    testDb.close();
+  });
+});
+
+describe("rooms", () => {
+  test("createRoom inserts a room with status waiting", () => {
+    const room = createRoom(db, "ABC123", "host-token-1");
+    expect(room.id).toBe("ABC123");
+    expect(room.host_token).toBe("host-token-1");
+    expect(room.guest_token).toBeNull();
+    expect(room.status).toBe("waiting");
+    expect(room.created_at).toBeTruthy();
+    expect(room.joined_at).toBeNull();
+    expect(room.closed_at).toBeNull();
+    expect(room.close_reason).toBeNull();
+  });
+
+  test("getRoom returns room by id", () => {
+    createRoom(db, "ABC123", "host-token-1");
+    const room = getRoom(db, "ABC123");
+    expect(room).not.toBeNull();
+    expect(room!.id).toBe("ABC123");
+  });
+
+  test("getRoom returns null for non-existent room", () => {
+    const room = getRoom(db, "NOPE00");
+    expect(room).toBeNull();
+  });
+
+  test("joinRoom transitions room to active", () => {
+    createRoom(db, "ABC123", "host-token-1");
+    const room = joinRoom(db, "ABC123", "guest-token-1");
+    expect(room.status).toBe("active");
+    expect(room.guest_token).toBe("guest-token-1");
+    expect(room.joined_at).toBeTruthy();
+  });
+
+  test("joinRoom throws if room not found", () => {
+    expect(() => joinRoom(db, "NOPE00", "guest-token")).toThrow(
+      "Room not found",
+    );
+  });
+
+  test("joinRoom throws if room is full", () => {
+    createRoom(db, "ABC123", "host-token-1");
+    joinRoom(db, "ABC123", "guest-token-1");
+    expect(() => joinRoom(db, "ABC123", "guest-token-2")).toThrow(
+      "Room is full",
+    );
+  });
+
+  test("joinRoom throws if room is expired", () => {
+    createRoom(db, "ABC123", "host-token-1");
+    expireRoom(db, "ABC123");
+    expect(() => joinRoom(db, "ABC123", "guest-token-1")).toThrow(
+      "Room is expired",
+    );
+  });
+
+  test("joinRoom throws if room is closed", () => {
+    createRoom(db, "ABC123", "host-token-1");
+    joinRoom(db, "ABC123", "guest-token-1");
+    closeRoom(db, "ABC123", "closed");
+    expect(() => joinRoom(db, "ABC123", "guest-token-2")).toThrow(
+      "Room is closed",
+    );
+  });
+
+  test("closeRoom sets status, closed_at, and close_reason", () => {
+    createRoom(db, "ABC123", "host-token-1");
+    joinRoom(db, "ABC123", "guest-token-1");
+    closeRoom(db, "ABC123", "timeout");
+    const room = getRoom(db, "ABC123")!;
+    expect(room.status).toBe("closed");
+    expect(room.closed_at).toBeTruthy();
+    expect(room.close_reason).toBe("timeout");
+  });
+
+  test("expireRoom sets status to expired", () => {
+    createRoom(db, "ABC123", "host-token-1");
+    expireRoom(db, "ABC123");
+    const room = getRoom(db, "ABC123")!;
+    expect(room.status).toBe("expired");
+    expect(room.closed_at).toBeTruthy();
+  });
+
+  test("getRoomByToken identifies host", () => {
+    createRoom(db, "ABC123", "host-token-1");
+    const result = getRoomByToken(db, "host-token-1");
+    expect(result).not.toBeNull();
+    expect(result!.role).toBe("host");
+    expect(result!.room.id).toBe("ABC123");
+  });
+
+  test("getRoomByToken identifies guest", () => {
+    createRoom(db, "ABC123", "host-token-1");
+    joinRoom(db, "ABC123", "guest-token-1");
+    const result = getRoomByToken(db, "guest-token-1");
+    expect(result).not.toBeNull();
+    expect(result!.role).toBe("guest");
+    expect(result!.room.id).toBe("ABC123");
+  });
+
+  test("getRoomByToken returns null for unknown token", () => {
+    const result = getRoomByToken(db, "unknown-token");
+    expect(result).toBeNull();
+  });
+});
+
+describe("messages", () => {
+  test("saveMessage inserts and returns a message", () => {
+    createRoom(db, "ABC123", "host-token-1");
+    const msg = saveMessage(db, "ABC123", "host", "Hello!");
+    expect(msg.id).toBeTruthy();
+    expect(msg.room_id).toBe("ABC123");
+    expect(msg.sender).toBe("host");
+    expect(msg.content).toBe("Hello!");
+    expect(msg.created_at).toBeTruthy();
+  });
+
+  test("getMessages returns all messages ordered by created_at", () => {
+    createRoom(db, "ABC123", "host-token-1");
+    saveMessage(db, "ABC123", "host", "First");
+    saveMessage(db, "ABC123", "host", "Second");
+    saveMessage(db, "ABC123", "guest", "Third");
+
+    const messages = getMessages(db, "ABC123");
+    expect(messages).toHaveLength(3);
+    expect(messages[0].content).toBe("First");
+    expect(messages[1].content).toBe("Second");
+    expect(messages[2].content).toBe("Third");
+  });
+
+  test("getMessages returns empty array for room with no messages", () => {
+    createRoom(db, "ABC123", "host-token-1");
+    const messages = getMessages(db, "ABC123");
+    expect(messages).toHaveLength(0);
+  });
+
+  test("getPendingMessages returns host messages sent before guest joined", () => {
+    createRoom(db, "ABC123", "host-token-1");
+
+    // Insert messages with explicit earlier timestamps
+    db.prepare(
+      `INSERT INTO messages (room_id, sender, content, created_at) VALUES (?, ?, ?, ?)`,
+    ).run("ABC123", "host", "Pending message 1", "2025-01-01 00:00:00");
+    db.prepare(
+      `INSERT INTO messages (room_id, sender, content, created_at) VALUES (?, ?, ?, ?)`,
+    ).run("ABC123", "host", "Pending message 2", "2025-01-01 00:00:01");
+
+    // Before joining, these should be pending
+    const pendingBefore = getPendingMessages(db, "ABC123");
+    expect(pendingBefore).toHaveLength(2);
+
+    // Set joined_at to a known time between pre-join messages and post-join messages
+    db.prepare(
+      `UPDATE rooms SET guest_token = ?, status = 'active', joined_at = ? WHERE id = ?`,
+    ).run("guest-token-1", "2025-01-01 00:00:10", "ABC123");
+
+    // Insert message after join
+    db.prepare(
+      `INSERT INTO messages (room_id, sender, content, created_at) VALUES (?, ?, ?, ?)`,
+    ).run("ABC123", "host", "After join", "2025-01-01 00:00:15");
+
+    const pending = getPendingMessages(db, "ABC123");
+    // Should still only have the 2 messages from before join
+    expect(pending).toHaveLength(2);
+    expect(pending[0].content).toBe("Pending message 1");
+    expect(pending[1].content).toBe("Pending message 2");
+  });
+
+  test("getPendingMessages excludes guest messages", () => {
+    createRoom(db, "ABC123", "host-token-1");
+    saveMessage(db, "ABC123", "host", "Host pending");
+    // guest messages before join shouldn't happen normally, but verify filter
+    const pending = getPendingMessages(db, "ABC123");
+    expect(pending).toHaveLength(1);
+    expect(pending[0].sender).toBe("host");
+  });
+});
+
+describe("generateRoomId", () => {
+  test("generates 6-character uppercase alphanumeric string", () => {
+    const id = generateRoomId();
+    expect(id).toHaveLength(6);
+    expect(id).toMatch(/^[A-Z0-9]{6}$/);
+  });
+
+  test("generates unique IDs", () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateRoomId()));
+    expect(ids.size).toBe(100);
+  });
+});
+
+describe("generateToken", () => {
+  test("generates UUID format token", () => {
+    const token = generateToken();
+    expect(token).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  test("generates unique tokens", () => {
+    const tokens = new Set(Array.from({ length: 100 }, () => generateToken()));
+    expect(tokens.size).toBe(100);
+  });
+});

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -1,0 +1,25 @@
+import { Database } from "bun:sqlite";
+import { customAlphabet } from "nanoid";
+import { initializeSchema } from "./schema.js";
+
+export { createRoom, getRoom, joinRoom, closeRoom, expireRoom, getRoomByToken } from "./rooms.js";
+export { saveMessage, getMessages, getPendingMessages } from "./messages.js";
+
+const DEFAULT_DB_PATH = "./agentmeets.db";
+
+export function createDatabase(path: string = DEFAULT_DB_PATH): Database {
+  const db = new Database(path);
+  initializeSchema(db);
+  return db;
+}
+
+const roomIdAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+const generateId = customAlphabet(roomIdAlphabet, 6);
+
+export function generateRoomId(): string {
+  return generateId();
+}
+
+export function generateToken(): string {
+  return crypto.randomUUID();
+}

--- a/packages/server/src/db/messages.ts
+++ b/packages/server/src/db/messages.ts
@@ -1,0 +1,36 @@
+import { Database } from "bun:sqlite";
+import type { Message, Sender } from "@agentmeets/shared";
+
+export function saveMessage(
+  db: Database,
+  roomId: string,
+  sender: Sender,
+  content: string,
+): Message {
+  const stmt = db.prepare(
+    `INSERT INTO messages (room_id, sender, content) VALUES (?, ?, ?) RETURNING *`,
+  );
+  return stmt.get(roomId, sender, content) as Message;
+}
+
+export function getMessages(db: Database, roomId: string): Message[] {
+  const stmt = db.prepare(
+    `SELECT * FROM messages WHERE room_id = ? ORDER BY created_at ASC, id ASC`,
+  );
+  return stmt.all(roomId) as Message[];
+}
+
+export function getPendingMessages(
+  db: Database,
+  roomId: string,
+): Message[] {
+  const stmt = db.prepare(
+    `SELECT m.* FROM messages m
+     JOIN rooms r ON m.room_id = r.id
+     WHERE m.room_id = ?
+       AND m.sender = 'host'
+       AND (r.joined_at IS NULL OR m.created_at < r.joined_at)
+     ORDER BY m.created_at ASC, m.id ASC`,
+  );
+  return stmt.all(roomId) as Message[];
+}

--- a/packages/server/src/db/rooms.ts
+++ b/packages/server/src/db/rooms.ts
@@ -1,0 +1,72 @@
+import { Database } from "bun:sqlite";
+import type { Room, CloseReason, Sender } from "@agentmeets/shared";
+
+export function createRoom(
+  db: Database,
+  id: string,
+  hostToken: string,
+): Room {
+  const stmt = db.prepare(
+    `INSERT INTO rooms (id, host_token, status) VALUES (?, ?, 'waiting') RETURNING *`,
+  );
+  return stmt.get(id, hostToken) as Room;
+}
+
+export function getRoom(db: Database, id: string): Room | null {
+  const stmt = db.prepare(`SELECT * FROM rooms WHERE id = ?`);
+  return (stmt.get(id) as Room) ?? null;
+}
+
+export function joinRoom(
+  db: Database,
+  id: string,
+  guestToken: string,
+): Room {
+  const room = getRoom(db, id);
+  if (!room) {
+    throw new Error("Room not found");
+  }
+  if (room.status === "expired" || room.status === "closed") {
+    throw new Error(`Room is ${room.status}`);
+  }
+  if (room.guest_token !== null) {
+    throw new Error("Room is full");
+  }
+
+  const stmt = db.prepare(
+    `UPDATE rooms SET guest_token = ?, status = 'active', joined_at = datetime('now') WHERE id = ? RETURNING *`,
+  );
+  return stmt.get(guestToken, id) as Room;
+}
+
+export function closeRoom(
+  db: Database,
+  id: string,
+  reason: CloseReason,
+): void {
+  const stmt = db.prepare(
+    `UPDATE rooms SET status = 'closed', closed_at = datetime('now'), close_reason = ? WHERE id = ?`,
+  );
+  stmt.run(reason, id);
+}
+
+export function expireRoom(db: Database, id: string): void {
+  const stmt = db.prepare(
+    `UPDATE rooms SET status = 'expired', closed_at = datetime('now') WHERE id = ?`,
+  );
+  stmt.run(id);
+}
+
+export function getRoomByToken(
+  db: Database,
+  token: string,
+): { room: Room; role: Sender } | null {
+  const stmt = db.prepare(
+    `SELECT * FROM rooms WHERE host_token = ? OR guest_token = ?`,
+  );
+  const room = stmt.get(token, token) as Room | undefined;
+  if (!room) return null;
+
+  const role: Sender = room.host_token === token ? "host" : "guest";
+  return { room, role };
+}

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1,0 +1,29 @@
+import { Database } from "bun:sqlite";
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS rooms (
+  id          TEXT PRIMARY KEY,
+  host_token  TEXT NOT NULL,
+  guest_token TEXT,
+  status      TEXT NOT NULL DEFAULT 'waiting',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  joined_at   TEXT,
+  closed_at   TEXT,
+  close_reason TEXT
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  room_id    TEXT NOT NULL REFERENCES rooms(id),
+  sender     TEXT NOT NULL,
+  content    TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_room ON messages(room_id);
+`;
+
+export function initializeSchema(db: Database): void {
+  db.exec("PRAGMA journal_mode = WAL;");
+  db.exec(SCHEMA);
+}

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["bun-types"]
+  },
+  "include": ["src"]
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@agentmeets/shared",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,7 @@
+export type {
+  Room,
+  RoomStatus,
+  CloseReason,
+  Sender,
+  Message,
+} from "./types.js";

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,0 +1,24 @@
+export type RoomStatus = "waiting" | "active" | "closed" | "expired";
+
+export type CloseReason = "closed" | "timeout" | "idle";
+
+export type Sender = "host" | "guest";
+
+export interface Room {
+  id: string;
+  host_token: string;
+  guest_token: string | null;
+  status: RoomStatus;
+  created_at: string;
+  joined_at: string | null;
+  closed_at: string | null;
+  close_reason: string | null;
+}
+
+export interface Message {
+  id: number;
+  room_id: string;
+  sender: Sender;
+  content: string;
+  created_at: string;
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
**@planner-03**

## Summary

Parent PR for AgentMeets V1 epic (#1). All child PRs target the `epic/1-agentmeets-v1` branch.

AgentMeets is an ephemeral agent-to-agent messaging service that lets MCP-compatible CLI agents create temporary chat rooms, exchange messages over WebSockets, and cleanly disconnect.

## Subtasks

- [ ] #2 — Scaffolding: monorepo structure, shared types, entry points
- [ ] #3 — Server: SQLite database layer for rooms and messages
- [ ] #4 — Server: REST API endpoints for room creation and joining
- [ ] #5 — Server: WebSocket relay and room lifecycle management
- [ ] #6 — MCP Server: Tool implementations for create, join, send, and end
- [ ] #7 — E2E integration tests for complete AgentMeets flow
- [ ] #13 — Dockerfile + README with setup instructions

## Test plan

- [ ] All child PRs merged and integrated on the epic branch
- [ ] Server starts and health check passes
- [ ] Full create → join → exchange → end flow works end-to-end
- [ ] Docker build succeeds
