### PR TITLE
Server: SQLite DB layer + REST API for rooms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.db
+.agent.lock

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,38 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "agentmeets",
+    },
+    "packages/server": {
+      "name": "@agentmeets/server",
+      "version": "0.1.0",
+      "dependencies": {
+        "hono": "^4.7.0",
+        "nanoid": "^5.1.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.2.0",
+        "typescript": "^5.7.0",
+      },
+    },
+  },
+  "packages": {
+    "@agentmeets/server": ["@agentmeets/server@workspace:packages/server"],
+
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "hono": ["hono@4.12.8", "", {}, "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A=="],
+
+    "nanoid": ["nanoid@5.1.7", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "agentmeets",
+  "private": true,
+  "workspaces": ["packages/*"]
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@agentmeets/server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun run src/index.ts",
+    "start": "bun run src/index.ts"
+  },
+  "dependencies": {
+    "hono": "^4.7.0",
+    "nanoid": "^5.1.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.2.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/server/src/db/db.ts
+++ b/packages/server/src/db/db.ts
@@ -1,0 +1,41 @@
+import { Database } from "bun:sqlite";
+
+let db: Database | null = null;
+
+export function getDb(): Database {
+  if (db) return db;
+
+  const dbPath = process.env.DATABASE_PATH ?? "./agentmeets.db";
+  db = new Database(dbPath, { create: true });
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS rooms (
+      id          TEXT PRIMARY KEY,
+      host_token  TEXT NOT NULL,
+      guest_token TEXT,
+      status      TEXT NOT NULL DEFAULT 'waiting',
+      created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+      joined_at   TEXT,
+      closed_at   TEXT,
+      close_reason TEXT
+    )
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS messages (
+      id         INTEGER PRIMARY KEY AUTOINCREMENT,
+      room_id    TEXT NOT NULL REFERENCES rooms(id),
+      sender     TEXT NOT NULL,
+      content    TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_messages_room ON messages(room_id)
+  `);
+
+  return db;
+}

--- a/packages/server/src/db/rooms.ts
+++ b/packages/server/src/db/rooms.ts
@@ -1,0 +1,107 @@
+import { customAlphabet } from "nanoid";
+import { randomBytes } from "crypto";
+import { getDb } from "./db";
+
+const generateRoomId = customAlphabet("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", 6);
+
+function generateToken(): string {
+  return randomBytes(32).toString("hex");
+}
+
+export interface Room {
+  id: string;
+  host_token: string;
+  guest_token: string | null;
+  status: string;
+  created_at: string;
+  joined_at: string | null;
+  closed_at: string | null;
+  close_reason: string | null;
+}
+
+export interface Message {
+  id: number;
+  room_id: string;
+  sender: string;
+  content: string;
+  created_at: string;
+}
+
+export function createRoom(): { id: string; hostToken: string } {
+  const db = getDb();
+  const id = generateRoomId();
+  const hostToken = generateToken();
+
+  db.prepare("INSERT INTO rooms (id, host_token) VALUES (?, ?)").run(
+    id,
+    hostToken
+  );
+
+  return { id, hostToken };
+}
+
+export function joinRoom(
+  roomId: string
+): { guestToken: string } | { error: "not_found" | "room_expired" | "room_full" } {
+  const db = getDb();
+  const room = db.prepare("SELECT * FROM rooms WHERE id = ?").get(roomId) as Room | null;
+
+  if (!room) {
+    return { error: "not_found" };
+  }
+
+  if (room.status === "expired") {
+    return { error: "room_expired" };
+  }
+
+  if (room.status === "active" || room.status === "closed") {
+    return { error: "room_full" };
+  }
+
+  const guestToken = generateToken();
+
+  db.prepare(
+    "UPDATE rooms SET guest_token = ?, joined_at = datetime('now'), status = 'active' WHERE id = ?"
+  ).run(guestToken, roomId);
+
+  return { guestToken };
+}
+
+export function closeRoom(roomId: string, reason: string): void {
+  const db = getDb();
+  db.prepare(
+    "UPDATE rooms SET status = 'closed', closed_at = datetime('now'), close_reason = ? WHERE id = ?"
+  ).run(reason, roomId);
+}
+
+export function expireRoom(roomId: string): void {
+  const db = getDb();
+  db.prepare(
+    "UPDATE rooms SET status = 'expired', closed_at = datetime('now') WHERE id = ?"
+  ).run(roomId);
+}
+
+export function getRoom(roomId: string): Room | null {
+  const db = getDb();
+  return db.prepare("SELECT * FROM rooms WHERE id = ?").get(roomId) as Room | null;
+}
+
+export function addMessage(
+  roomId: string,
+  sender: string,
+  content: string
+): void {
+  const db = getDb();
+  db.prepare(
+    "INSERT INTO messages (room_id, sender, content) VALUES (?, ?, ?)"
+  ).run(roomId, sender, content);
+}
+
+export function getPendingMessages(roomId: string): Message[] {
+  const db = getDb();
+  return db
+    .prepare(
+      "SELECT m.* FROM messages m JOIN rooms r ON m.room_id = r.id WHERE m.room_id = ? AND m.created_at <= COALESCE(r.joined_at, datetime('now')) ORDER BY m.id ASC"
+    )
+    .all(roomId) as Message[];
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,0 +1,18 @@
+import { Hono } from "hono";
+import { getDb } from "./db/db";
+import rooms from "./routes/rooms";
+
+// Initialize database on startup
+getDb();
+
+const app = new Hono();
+app.route("/rooms", rooms);
+
+const port = parseInt(process.env.PORT ?? "3000", 10);
+
+export default {
+  port,
+  fetch: app.fetch.bind(app),
+};
+
+console.log(`AgentMeets server running on port ${port}`);

--- a/packages/server/src/routes/rooms.ts
+++ b/packages/server/src/routes/rooms.ts
@@ -1,0 +1,64 @@
+import { Hono } from "hono";
+import { createRoom, joinRoom } from "../db/rooms";
+
+// Simple in-memory rate limiter: max 10 join attempts per IP per minute
+const joinAttempts = new Map<string, { count: number; resetAt: number }>();
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const entry = joinAttempts.get(ip);
+
+  if (!entry || now >= entry.resetAt) {
+    joinAttempts.set(ip, { count: 1, resetAt: now + 60_000 });
+    return false;
+  }
+
+  entry.count++;
+  return entry.count > 10;
+}
+
+// Clean up expired rate limit entries periodically
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, entry] of joinAttempts) {
+    if (now >= entry.resetAt) {
+      joinAttempts.delete(ip);
+    }
+  }
+}, 60_000);
+
+const rooms = new Hono();
+
+rooms.post("/", (c) => {
+  const room = createRoom();
+  return c.json({ roomId: room.id, hostToken: room.hostToken }, 201);
+});
+
+rooms.post("/:id/join", (c) => {
+  const ip =
+    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ??
+    c.req.header("x-real-ip") ??
+    "unknown";
+
+  if (isRateLimited(ip)) {
+    return c.json({ error: "rate_limited" }, 429);
+  }
+
+  const roomId = c.req.param("id");
+  const result = joinRoom(roomId);
+
+  if ("error" in result) {
+    switch (result.error) {
+      case "not_found":
+        return c.json({ error: "not_found" }, 404);
+      case "room_expired":
+        return c.json({ error: "room_expired" }, 410);
+      case "room_full":
+        return c.json({ error: "room_full" }, 409);
+    }
+  }
+
+  return c.json({ guestToken: result.guestToken }, 200);
+});
+
+export default rooms;

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["bun"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
**@worker-05**

## Summary
- Implements SQLite database layer using `bun:sqlite` with auto-initialization and configurable path via `DATABASE_PATH` env var
- Adds REST API endpoints: `POST /rooms` (201 with roomId + hostToken) and `POST /rooms/:id/join` (200/404/409/410)
- Includes in-memory rate limiting (10 join attempts/IP/min) with automatic cleanup
- Room IDs are 6-char uppercase alphanumeric (nanoid), tokens are 64-char crypto random hex

## Test plan
- [ ] Verify `POST /rooms` returns 201 with valid roomId (6 chars, uppercase alphanumeric) and hostToken (64 hex chars)
- [ ] Verify `POST /rooms/:id/join` returns 200 with guestToken for waiting rooms
- [ ] Verify 404 for non-existent rooms, 409 for active/closed rooms, 410 for expired rooms
- [ ] Verify rate limiting triggers 429 after 10 join attempts per minute
- [ ] Verify database auto-creates on startup
- [ ] Verify `DATABASE_PATH` env var configures DB location

🤖 Generated with [Claude Code](https://claude.com/claude-code)
