### PR TITLE
MCP Server: 4 tools (create_meet, join_meet, send_and_wait, end_meet)

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@agentmeets/mcp-server",
+  "version": "0.1.0",
+  "type": "module",
+  "bin": {
+    "agentmeets-mcp": "./src/index.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "bun-types": "latest"
+  }
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,0 +1,294 @@
+#!/usr/bin/env bun
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const SERVER_URL =
+  process.env.AGENTMEETS_URL?.replace(/\/$/, "") || "http://localhost:3000";
+
+interface MeetState {
+  roomId: string;
+  token: string;
+  role: "host" | "guest";
+  ws: WebSocket | null;
+  collectingPending: string[] | null;
+  pendingReply: {
+    resolve: (result: { content: string | null; reason?: string }) => void;
+  } | null;
+}
+
+let meetState: MeetState | null = null;
+
+function wsUrl(roomId: string, token: string): string {
+  const base = SERVER_URL.replace(/^http/, "ws");
+  return `${base}/rooms/${roomId}/ws?token=${token}`;
+}
+
+function clearState(): void {
+  if (meetState?.ws) {
+    try {
+      meetState.ws.close();
+    } catch {}
+  }
+  meetState = null;
+}
+
+function resolvePending(
+  content: string | null,
+  reason?: string
+): void {
+  if (meetState?.pendingReply) {
+    const { resolve } = meetState.pendingReply;
+    meetState.pendingReply = null;
+    resolve({ content, reason });
+  }
+}
+
+function attachListeners(ws: WebSocket): void {
+  ws.addEventListener("message", (event) => {
+    const data = JSON.parse(String(event.data));
+    switch (data.type) {
+      case "message":
+        if (meetState?.collectingPending) {
+          meetState.collectingPending.push(data.content);
+        } else {
+          resolvePending(data.content);
+        }
+        break;
+      case "joined":
+        break;
+      case "ended":
+        resolvePending(null, data.reason ?? "closed");
+        clearState();
+        break;
+    }
+  });
+
+  ws.addEventListener("close", () => {
+    resolvePending(null, "closed");
+    meetState = null;
+  });
+
+  ws.addEventListener("error", () => {
+    resolvePending(null, "closed");
+    meetState = null;
+  });
+}
+
+function waitForOpen(ws: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (ws.readyState === WebSocket.OPEN) {
+      resolve();
+      return;
+    }
+    ws.addEventListener("open", () => resolve(), { once: true });
+    ws.addEventListener("error", (e) => reject(e), { once: true });
+  });
+}
+
+function errorResult(msg: string) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify({ error: msg }) }],
+    isError: true,
+  };
+}
+
+function textResult(data: object) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data) }],
+  };
+}
+
+const server = new McpServer({
+  name: "agentmeets",
+  version: "0.1.0",
+});
+
+server.tool(
+  "create_meet",
+  "Create a new AgentMeets room and wait for a guest to join",
+  {
+    timeout: z
+      .number()
+      .optional()
+      .default(300)
+      .describe("Seconds to wait for guest"),
+  },
+  async ({ timeout }) => {
+    if (meetState) {
+      return errorResult("A meet is already active. Call end_meet first.");
+    }
+
+    let res: Response;
+    try {
+      res = await fetch(`${SERVER_URL}/rooms`, { method: "POST" });
+    } catch (err) {
+      return errorResult(`Cannot reach server at ${SERVER_URL}: ${err}`);
+    }
+
+    const { roomId, hostToken } = await res.json();
+
+    const ws = new WebSocket(wsUrl(roomId, hostToken));
+    meetState = {
+      roomId,
+      token: hostToken,
+      role: "host",
+      ws,
+      collectingPending: null,
+      pendingReply: null,
+    };
+
+    attachListeners(ws);
+
+    try {
+      await waitForOpen(ws);
+    } catch {
+      clearState();
+      return errorResult("WebSocket connection failed");
+    }
+
+    return textResult({ roomId, status: "waiting" });
+  }
+);
+
+server.tool(
+  "join_meet",
+  "Join an existing AgentMeets room by room code",
+  {
+    roomId: z.string().describe("Room code to join"),
+  },
+  async ({ roomId }) => {
+    if (meetState) {
+      return errorResult("A meet is already active. Call end_meet first.");
+    }
+
+    let res: Response;
+    try {
+      res = await fetch(`${SERVER_URL}/rooms/${roomId}/join`, {
+        method: "POST",
+      });
+    } catch (err) {
+      return errorResult(`Cannot reach server at ${SERVER_URL}: ${err}`);
+    }
+
+    if (!res.ok) {
+      const statusErrors: Record<number, string> = {
+        404: "Room not found",
+        409: "Room is full",
+        410: "Room has expired",
+      };
+      return errorResult(
+        statusErrors[res.status] ?? `Server error: ${res.status}`
+      );
+    }
+
+    const { guestToken } = await res.json();
+
+    const pendingMessages: string[] = [];
+    const ws = new WebSocket(wsUrl(roomId, guestToken));
+
+    meetState = {
+      roomId,
+      token: guestToken,
+      role: "guest",
+      ws,
+      collectingPending: pendingMessages,
+      pendingReply: null,
+    };
+
+    attachListeners(ws);
+
+    try {
+      await waitForOpen(ws);
+    } catch {
+      clearState();
+      return errorResult("WebSocket connection failed");
+    }
+
+    // Brief window to collect pending messages delivered by the server on connect
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Stop collecting — future messages go to pendingReply
+    if (meetState) {
+      meetState.collectingPending = null;
+    }
+
+    return textResult({
+      roomId,
+      status: "connected",
+      pending: pendingMessages,
+    });
+  }
+);
+
+server.tool(
+  "send_and_wait",
+  "Send a message and wait for a reply from the other participant",
+  {
+    message: z.string().describe("Message to send"),
+    timeout: z
+      .number()
+      .optional()
+      .default(120)
+      .describe("Max seconds to wait for reply"),
+  },
+  async ({ message, timeout }) => {
+    if (!meetState) {
+      return errorResult(
+        "No active meet. Call create_meet or join_meet first."
+      );
+    }
+
+    if (!meetState.ws || meetState.ws.readyState !== WebSocket.OPEN) {
+      clearState();
+      return errorResult("Connection lost");
+    }
+
+    meetState.ws.send(JSON.stringify({ type: "message", content: message }));
+
+    const result = await new Promise<{
+      content: string | null;
+      reason?: string;
+    }>((resolve) => {
+      meetState!.pendingReply = { resolve };
+
+      setTimeout(() => {
+        if (meetState?.pendingReply?.resolve === resolve) {
+          meetState.pendingReply = null;
+          resolve({ content: null, reason: "timeout" });
+        }
+      }, timeout * 1000);
+    });
+
+    if (result.content !== null) {
+      return textResult({ reply: result.content, status: "ok" });
+    }
+
+    const reason = result.reason ?? (meetState === null ? "closed" : "timeout");
+    clearState();
+    return textResult({ reply: null, status: "ended", reason });
+  }
+);
+
+server.tool(
+  "end_meet",
+  "End the current meet and disconnect",
+  {},
+  async () => {
+    if (!meetState) {
+      return errorResult("No active meet");
+    }
+
+    if (meetState.ws && meetState.ws.readyState === WebSocket.OPEN) {
+      meetState.ws.send(JSON.stringify({ type: "end" }));
+    }
+
+    clearState();
+
+    return textResult({ status: "ended" });
+  }
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["bun-types"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
**@worker-01**

## Summary
- Adds `@agentmeets/mcp-server` package with stdio transport exposing 4 MCP tools: `create_meet`, `join_meet`, `send_and_wait`, `end_meet`
- Manages WebSocket connections internally — agents interact only via tool calls
- Server URL configurable via `AGENTMEETS_URL` env var (default `http://localhost:3000`)

## Details

The MCP server maintains a single active meet state. Each tool handles:
- **create_meet**: POST /rooms to create a room, opens WebSocket as host, returns `{ roomId, status: "waiting" }`
- **join_meet**: POST /rooms/:id/join, opens WebSocket as guest, collects pending messages, returns `{ roomId, status: "connected", pending: [...] }`
- **send_and_wait**: Sends message over WebSocket, blocks until reply/timeout/end, returns `{ reply, status }` 
- **end_meet**: Sends end frame, closes WebSocket, clears state

Error handling covers: duplicate meets, unreachable server, HTTP error codes (404/409/410), WebSocket failures, unexpected disconnects, and timeouts.

Package includes `bin` entry for `npx @agentmeets/mcp-server` execution with `#!/usr/bin/env bun` shebang.

## Test plan
- [ ] Verify MCP server starts via stdio transport (`bun packages/mcp-server/src/index.ts`)
- [ ] Verify `create_meet` creates a room against a running server
- [ ] Verify `join_meet` joins a room and receives pending messages
- [ ] Verify `send_and_wait` sends and receives replies with timeout handling
- [ ] Verify `end_meet` cleanly closes connection
- [ ] Verify error cases (double create, no active meet, server unreachable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
