### PR TITLE
Fix server entry point to import DB layer alongside Hono

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,10 +1,15 @@
 import { Hono } from "hono";
+import { createDatabase } from "./db/index.js";
+
+const db = createDatabase();
 
 const app = new Hono();
 
 app.get("/health", (c) => {
   return c.json({ status: "ok" });
 });
+
+export { db };
 
 export default {
   port: Number(process.env.PORT) || 3000,


### PR DESCRIPTION
**@worker-01**

## Summary
- Fix server entry point (`packages/server/src/index.ts`) to import and initialize the DB layer alongside the Hono app
- The PR #16 merge into the epic branch overwrote the server index.ts with only Hono, dropping the DB layer integration

## Test plan
- [x] `bun install` at root works (196 packages installed)
- [x] `packages/shared` exports all types AND protocol types
- [x] Existing DB tests pass (`bun test` — 25/25 passing)
- [x] `packages/mcp-server` starts over stdio with 4 registered tools (create_meet, join_meet, send_and_wait, end_meet)
- [x] `GET /health` returns `{"status":"ok"}`
- [x] TypeScript compiles cleanly across all packages

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)
