### PR TITLE
Fix: byte-length check and duplicate connection guard (#28)

### DIFF
--- a/packages/server/src/ws/room-manager.ts
+++ b/packages/server/src/ws/room-manager.ts
@@ -80,7 +80,7 @@ export class RoomManager {
   }
 
   handleMessage(roomId: string, senderRole: Sender, content: string): boolean {
-    if (content.length > MAX_MESSAGE_SIZE) {
+    if (Buffer.byteLength(content, "utf8") > MAX_MESSAGE_SIZE) {
       return false;
     }
 

--- a/packages/server/src/ws/upgrade.ts
+++ b/packages/server/src/ws/upgrade.ts
@@ -33,6 +33,10 @@ export function handleUpgrade(
     return new Response("Room is no longer available", { status: 410 });
   }
 
+  if (roomManager.getConnection(result.room.id, result.role)) {
+    return new Response("Role already connected", { status: 409 });
+  }
+
   const wsData: WsData = { roomId, role: result.role };
 
   const upgraded = server.upgrade(req, { data: wsData });

--- a/packages/server/tests/ws.test.ts
+++ b/packages/server/tests/ws.test.ts
@@ -263,6 +263,44 @@ describe("WebSocket relay — integration tests", () => {
     guestWs.close();
   });
 
+  test("message size limit enforced by byte length, not character count", async () => {
+    const hostWs = connectAs("host-token-123");
+    await waitForOpen(hostWs);
+
+    const guestWs = connectAs("guest-token-456");
+    await waitForOpen(guestWs);
+    await waitForMessage(hostWs); // consume 'joined'
+
+    // Each emoji (e.g. 🎉) is 4 bytes in UTF-8 but 2 UTF-16 code units.
+    // 25601 emoji × 4 bytes = 102404 bytes > 100KB, but only 51202 UTF-16 code units.
+    const closePromise = waitForClose(hostWs);
+    const emoji = "🎉";
+    const count = Math.ceil((100 * 1024 + 1) / Buffer.byteLength(emoji, "utf8"));
+    const bigContent = emoji.repeat(count);
+    expect(bigContent.length).toBeLessThan(100 * 1024); // under limit by character count
+    expect(Buffer.byteLength(bigContent, "utf8")).toBeGreaterThan(100 * 1024); // over limit by byte length
+    hostWs.send(JSON.stringify({ type: "message", content: bigContent }));
+    const close = await closePromise;
+    expect(close.code).toBe(1009);
+
+    guestWs.close();
+  });
+
+  test("rejects duplicate connection for same role", async () => {
+    const hostWs1 = connectAs("host-token-123");
+    await waitForOpen(hostWs1);
+
+    // Second connection with the same host token should be rejected (409)
+    const hostWs2 = connectAs("host-token-123");
+    const close = await waitForClose(hostWs2);
+    expect(close.code).not.toBe(1000);
+
+    // Original connection should still be open
+    expect(hostWs1.readyState).toBe(WebSocket.OPEN);
+
+    hostWs1.close();
+  });
+
   test("rejects connection to closed room", async () => {
     closeRoom(db, "ROOM01", "closed");
 


### PR DESCRIPTION
**@worker-04**

## Summary
- Fix message size validation to use `Buffer.byteLength(content, 'utf8')` instead of `content.length`, preventing multi-byte characters (emoji, CJK) from bypassing the 100KB limit
- Reject duplicate WebSocket connections for the same role in the upgrade handler with HTTP 409, preventing zombie connections from silent overwrites
- Add tests for both fixes: multi-byte boundary check and duplicate connection rejection

## Test plan
- [x] All 19 existing tests pass (0 failures)
- [x] New test: multi-byte emoji content exceeding byte limit but under character limit is correctly rejected (code 1009)
- [x] New test: second connection for same role is rejected while original stays open
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
