### PR TITLE
Add REST API endpoints for room creation and joining

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { createDatabase } from "./db/index.js";
 import { RoomManager, createWebSocketHandlers, handleUpgrade } from "./ws/index.js";
 import type { WsData } from "./ws/index.js";
+import { roomRoutes } from "./routes/rooms.js";
 
 export function createServer(port = 3000) {
   const db = createDatabase();
@@ -10,6 +11,7 @@ export function createServer(port = 3000) {
   const wsHandlers = createWebSocketHandlers(roomManager);
 
   app.get("/health", (c) => c.json({ status: "ok" }));
+  app.route("/", roomRoutes(db));
 
   const server = Bun.serve<WsData>({
     port,

--- a/packages/server/src/middleware/rate-limit.ts
+++ b/packages/server/src/middleware/rate-limit.ts
@@ -1,0 +1,42 @@
+import type { Context, Next } from "hono";
+
+interface RateLimitEntry {
+  count: number;
+  resetTime: number;
+}
+
+export function rateLimiter(maxRequests = 10, windowMs = 60_000) {
+  const clients = new Map<string, RateLimitEntry>();
+
+  // Periodically clean up expired entries
+  setInterval(() => {
+    const now = Date.now();
+    for (const [ip, entry] of clients) {
+      if (now >= entry.resetTime) {
+        clients.delete(ip);
+      }
+    }
+  }, windowMs).unref();
+
+  return async (c: Context, next: Next) => {
+    const ip =
+      c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ??
+      c.req.header("x-real-ip") ??
+      "unknown";
+
+    const now = Date.now();
+    const entry = clients.get(ip);
+
+    if (!entry || now >= entry.resetTime) {
+      clients.set(ip, { count: 1, resetTime: now + windowMs });
+      return next();
+    }
+
+    entry.count++;
+    if (entry.count > maxRequests) {
+      return c.json({ error: "rate_limit_exceeded" }, 429);
+    }
+
+    return next();
+  };
+}

--- a/packages/server/src/routes/rooms.test.ts
+++ b/packages/server/src/routes/rooms.test.ts
@@ -1,0 +1,147 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { Hono } from "hono";
+import { Database } from "bun:sqlite";
+import { initializeSchema } from "../db/schema.js";
+import { createRoom, joinRoom, expireRoom, closeRoom } from "../db/rooms.js";
+import { roomRoutes } from "./rooms.js";
+
+let db: Database;
+let app: Hono;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  initializeSchema(db);
+  app = new Hono();
+  app.route("/", roomRoutes(db));
+});
+
+describe("POST /rooms", () => {
+  test("returns 201 with roomId and hostToken", async () => {
+    const res = await app.request("/rooms", { method: "POST" });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.roomId).toMatch(/^[A-Z0-9]{6}$/);
+    expect(body.hostToken).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  test("creates room in database", async () => {
+    const res = await app.request("/rooms", { method: "POST" });
+    const body = await res.json();
+    const stmt = db.prepare("SELECT * FROM rooms WHERE id = ?");
+    const room = stmt.get(body.roomId) as { id: string; status: string };
+    expect(room).not.toBeNull();
+    expect(room.status).toBe("waiting");
+  });
+});
+
+describe("POST /rooms/:id/join", () => {
+  test("returns 200 with guestToken for a waiting room", async () => {
+    createRoom(db, "ABC123", "host-token");
+    const res = await app.request("/rooms/ABC123/join", { method: "POST" });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.guestToken).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  test("returns 404 for nonexistent room", async () => {
+    const res = await app.request("/rooms/NOPE00/join", { method: "POST" });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("room_not_found");
+  });
+
+  test("returns 409 for room that already has a guest", async () => {
+    createRoom(db, "ABC123", "host-token");
+    joinRoom(db, "ABC123", "guest-token-1");
+    const res = await app.request("/rooms/ABC123/join", { method: "POST" });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe("room_full");
+  });
+
+  test("returns 410 for expired room", async () => {
+    createRoom(db, "ABC123", "host-token");
+    expireRoom(db, "ABC123");
+    const res = await app.request("/rooms/ABC123/join", { method: "POST" });
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body.error).toBe("room_expired");
+  });
+
+  test("returns 410 for closed room", async () => {
+    createRoom(db, "ABC123", "host-token");
+    joinRoom(db, "ABC123", "guest-token-1");
+    closeRoom(db, "ABC123", "closed");
+    const res = await app.request("/rooms/ABC123/join", { method: "POST" });
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body.error).toBe("room_expired");
+  });
+
+  test("returns 400 for malformed room ID (too short)", async () => {
+    const res = await app.request("/rooms/ABC/join", { method: "POST" });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_room_id");
+  });
+
+  test("returns 400 for malformed room ID (lowercase)", async () => {
+    const res = await app.request("/rooms/abc123/join", { method: "POST" });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_room_id");
+  });
+
+  test("returns 400 for malformed room ID (special chars)", async () => {
+    const res = await app.request("/rooms/AB-1!3/join", { method: "POST" });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_room_id");
+  });
+
+  test("rate limits excessive join attempts", async () => {
+    createRoom(db, "ABC123", "host-token");
+
+    // First 10 attempts should not be rate limited (room will be full after 1st)
+    for (let i = 0; i < 10; i++) {
+      const res = await app.request("/rooms/ABC123/join", {
+        method: "POST",
+        headers: { "x-forwarded-for": "1.2.3.4" },
+      });
+      // First succeeds, rest get 409 (full), but none should be 429
+      expect(res.status).not.toBe(429);
+    }
+
+    // 11th attempt should be rate limited
+    const res = await app.request("/rooms/ABC123/join", {
+      method: "POST",
+      headers: { "x-forwarded-for": "1.2.3.4" },
+    });
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("rate_limit_exceeded");
+  });
+
+  test("rate limit is per-IP", async () => {
+    createRoom(db, "ABC123", "host-token");
+
+    // Exhaust rate limit for IP 1.2.3.4
+    for (let i = 0; i < 11; i++) {
+      await app.request("/rooms/ABC123/join", {
+        method: "POST",
+        headers: { "x-forwarded-for": "1.2.3.4" },
+      });
+    }
+
+    // Different IP should still work
+    const res = await app.request("/rooms/ABC123/join", {
+      method: "POST",
+      headers: { "x-forwarded-for": "5.6.7.8" },
+    });
+    expect(res.status).not.toBe(429);
+  });
+});

--- a/packages/server/src/routes/rooms.ts
+++ b/packages/server/src/routes/rooms.ts
@@ -1,0 +1,58 @@
+import { Hono } from "hono";
+import type { Database } from "bun:sqlite";
+import { createRoom, getRoom, joinRoom, generateRoomId, generateToken } from "../db/index.js";
+import { rateLimiter } from "../middleware/rate-limit.js";
+
+const ROOM_ID_PATTERN = /^[A-Z0-9]{6}$/;
+const MAX_COLLISION_RETRIES = 3;
+
+export function roomRoutes(db: Database): Hono {
+  const router = new Hono();
+
+  router.post("/rooms", async (c) => {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < MAX_COLLISION_RETRIES; attempt++) {
+      const roomId = generateRoomId();
+      const hostToken = generateToken();
+      try {
+        createRoom(db, roomId, hostToken);
+        return c.json({ roomId, hostToken }, 201);
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        if (msg.includes("UNIQUE constraint failed") || msg.includes("PRIMARY KEY")) {
+          lastError = e;
+          continue;
+        }
+        throw e;
+      }
+    }
+    throw lastError;
+  });
+
+  const joinRateLimit = rateLimiter(10, 60_000);
+
+  router.post("/rooms/:id/join", joinRateLimit, async (c) => {
+    const id = c.req.param("id");
+
+    if (!ROOM_ID_PATTERN.test(id)) {
+      return c.json({ error: "invalid_room_id" }, 400);
+    }
+
+    const room = getRoom(db, id);
+    if (!room) {
+      return c.json({ error: "room_not_found" }, 404);
+    }
+    if (room.status === "expired" || room.status === "closed") {
+      return c.json({ error: "room_expired" }, 410);
+    }
+    if (room.guest_token !== null) {
+      return c.json({ error: "room_full" }, 409);
+    }
+
+    const guestToken = generateToken();
+    joinRoom(db, id, guestToken);
+    return c.json({ guestToken }, 200);
+  });
+
+  return router;
+}


### PR DESCRIPTION
**@worker-05**

## Summary
- Add `POST /rooms` endpoint returning 201 with `roomId` and `hostToken`
- Add `POST /rooms/:id/join` endpoint with proper error responses (400/404/409/410)
- Add in-memory rate limiting middleware (10 requests/IP/minute) on join endpoint
- Add room ID collision retry logic (up to 3 attempts)
- Add comprehensive tests covering all success and error paths

## Test plan
- [x] `POST /rooms` returns 201 with valid roomId (6-char uppercase alphanum) and hostToken (UUID)
- [x] `POST /rooms/:id/join` returns 200 with guestToken for waiting room
- [x] Join returns 404 for nonexistent rooms
- [x] Join returns 409 for full rooms
- [x] Join returns 410 for expired/closed rooms
- [x] Join returns 400 for malformed room IDs
- [x] Rate limiting blocks excessive join attempts from same IP
- [x] Rate limiting is per-IP (different IPs not affected)
- [x] All 71 tests pass (existing + new)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
