### PR TITLE
Implement MCP server tools with review fixes (supersedes #24)

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,6 +1,111 @@
+#!/usr/bin/env bun
+
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+import type { ServerMessage, ClientMessage } from "@agentmeets/shared";
+
+const SERVER_URL =
+  process.env.AGENTMEETS_URL?.replace(/\/$/, "") || "http://localhost:3000";
+
+interface MeetState {
+  roomId: string;
+  token: string;
+  role: "host" | "guest";
+  ws: WebSocket | null;
+  collectingPending: string[] | null;
+  pendingReply: {
+    resolve: (result: { content: string | null; reason?: string }) => void;
+  } | null;
+}
+
+let meetState: MeetState | null = null;
+
+function wsUrl(roomId: string, token: string): string {
+  const base = SERVER_URL.replace(/^http/, "ws");
+  return `${base}/rooms/${roomId}/ws?token=${token}`;
+}
+
+function clearState(): void {
+  if (meetState?.ws) {
+    try {
+      meetState.ws.close();
+    } catch {}
+  }
+  meetState = null;
+}
+
+function resolvePending(
+  content: string | null,
+  reason?: string
+): void {
+  if (meetState?.pendingReply) {
+    const { resolve } = meetState.pendingReply;
+    meetState.pendingReply = null;
+    resolve({ content, reason });
+  }
+}
+
+function attachListeners(ws: WebSocket): void {
+  ws.addEventListener("message", (event) => {
+    let data: ServerMessage;
+    try {
+      data = JSON.parse(String(event.data));
+    } catch {
+      return; // ignore malformed messages
+    }
+
+    switch (data.type) {
+      case "message":
+        if (meetState?.collectingPending) {
+          meetState.collectingPending.push(data.content);
+        } else {
+          resolvePending(data.content);
+        }
+        break;
+      case "joined":
+        break;
+      case "ended":
+        resolvePending(null, data.reason ?? "closed");
+        clearState();
+        break;
+    }
+  });
+
+  ws.addEventListener("close", () => {
+    resolvePending(null, "closed");
+    meetState = null;
+  });
+
+  ws.addEventListener("error", () => {
+    resolvePending(null, "closed");
+    meetState = null;
+  });
+}
+
+function waitForOpen(ws: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (ws.readyState === WebSocket.OPEN) {
+      resolve();
+      return;
+    }
+    ws.addEventListener("open", () => resolve(), { once: true });
+    ws.addEventListener("error", (e) => reject(e), { once: true });
+  });
+}
+
+function errorResult(msg: string) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify({ error: msg }) }],
+    isError: true,
+  };
+}
+
+function textResult(data: object) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data) }],
+  };
+}
 
 const server = new McpServer({
   name: "agentmeets",
@@ -9,50 +114,192 @@ const server = new McpServer({
 
 server.tool(
   "create_meet",
-  "Create a new ephemeral meet room and connect to it",
+  "Create a new AgentMeets room and wait for a guest to join",
   {
     timeout: z
       .number()
       .optional()
-      .describe("Seconds to wait for guest to join before room expires"),
+      .default(300)
+      .describe("Seconds to wait for guest"),
   },
-  async () => {
-    return { content: [{ type: "text", text: JSON.stringify({ error: "not implemented" }) }] };
+  async ({ timeout }) => {
+    if (meetState) {
+      return errorResult("A meet is already active. Call end_meet first.");
+    }
+
+    let res: Response;
+    try {
+      res = await fetch(`${SERVER_URL}/rooms`, { method: "POST" });
+    } catch (err) {
+      return errorResult(`Cannot reach server at ${SERVER_URL}: ${err}`);
+    }
+
+    if (!res.ok) {
+      return errorResult(`Server error creating room: ${res.status}`);
+    }
+
+    const { roomId, hostToken } = await res.json();
+
+    const ws = new WebSocket(wsUrl(roomId, hostToken));
+    meetState = {
+      roomId,
+      token: hostToken,
+      role: "host",
+      ws,
+      collectingPending: null,
+      pendingReply: null,
+    };
+
+    attachListeners(ws);
+
+    try {
+      await waitForOpen(ws);
+    } catch {
+      clearState();
+      return errorResult("WebSocket connection failed");
+    }
+
+    return textResult({ roomId, status: "waiting" });
   }
 );
 
 server.tool(
   "join_meet",
-  "Join an existing meet room by its code",
+  "Join an existing AgentMeets room by room code",
   {
-    roomId: z.string().describe("The room code to join"),
+    roomId: z.string().describe("Room code to join"),
   },
-  async () => {
-    return { content: [{ type: "text", text: JSON.stringify({ error: "not implemented" }) }] };
+  async ({ roomId }) => {
+    if (meetState) {
+      return errorResult("A meet is already active. Call end_meet first.");
+    }
+
+    let res: Response;
+    try {
+      res = await fetch(`${SERVER_URL}/rooms/${roomId}/join`, {
+        method: "POST",
+      });
+    } catch (err) {
+      return errorResult(`Cannot reach server at ${SERVER_URL}: ${err}`);
+    }
+
+    if (!res.ok) {
+      const statusErrors: Record<number, string> = {
+        404: "Room not found",
+        409: "Room is full",
+        410: "Room has expired",
+      };
+      return errorResult(
+        statusErrors[res.status] ?? `Server error: ${res.status}`
+      );
+    }
+
+    const { guestToken } = await res.json();
+
+    const pendingMessages: string[] = [];
+    const ws = new WebSocket(wsUrl(roomId, guestToken));
+
+    meetState = {
+      roomId,
+      token: guestToken,
+      role: "guest",
+      ws,
+      collectingPending: pendingMessages,
+      pendingReply: null,
+    };
+
+    attachListeners(ws);
+
+    try {
+      await waitForOpen(ws);
+    } catch {
+      clearState();
+      return errorResult("WebSocket connection failed");
+    }
+
+    // Brief window to collect pending messages delivered by the server on connect
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Stop collecting — future messages go to pendingReply
+    if (meetState) {
+      meetState.collectingPending = null;
+    }
+
+    return textResult({
+      roomId,
+      status: "connected",
+      pending: pendingMessages,
+    });
   }
 );
 
 server.tool(
   "send_and_wait",
-  "Send a message to the other agent and wait for a reply",
+  "Send a message and wait for a reply from the other participant",
   {
-    message: z.string().describe("The message to send"),
+    message: z.string().describe("Message to send"),
     timeout: z
       .number()
       .optional()
-      .describe("Max seconds to wait for a reply"),
+      .default(120)
+      .describe("Max seconds to wait for reply"),
   },
-  async () => {
-    return { content: [{ type: "text", text: JSON.stringify({ error: "not implemented" }) }] };
+  async ({ message, timeout }) => {
+    if (!meetState) {
+      return errorResult(
+        "No active meet. Call create_meet or join_meet first."
+      );
+    }
+
+    if (!meetState.ws || meetState.ws.readyState !== WebSocket.OPEN) {
+      clearState();
+      return errorResult("Connection lost");
+    }
+
+    const payload: ClientMessage = { type: "message", content: message };
+    meetState.ws.send(JSON.stringify(payload));
+
+    const result = await new Promise<{
+      content: string | null;
+      reason?: string;
+    }>((resolve) => {
+      meetState!.pendingReply = { resolve };
+
+      setTimeout(() => {
+        if (meetState?.pendingReply?.resolve === resolve) {
+          meetState.pendingReply = null;
+          resolve({ content: null, reason: "timeout" });
+        }
+      }, timeout * 1000);
+    });
+
+    if (result.content !== null) {
+      return textResult({ reply: result.content, status: "ok" });
+    }
+
+    const reason = result.reason ?? (meetState === null ? "closed" : "timeout");
+    clearState();
+    return textResult({ reply: null, status: "ended", reason });
   }
 );
 
 server.tool(
   "end_meet",
-  "Close the room and disconnect both agents",
+  "End the current meet and disconnect",
   {},
   async () => {
-    return { content: [{ type: "text", text: JSON.stringify({ error: "not implemented" }) }] };
+    if (!meetState) {
+      return errorResult("No active meet");
+    }
+
+    if (meetState.ws && meetState.ws.readyState === WebSocket.OPEN) {
+      const payload: ClientMessage = { type: "end" };
+      meetState.ws.send(JSON.stringify(payload));
+    }
+
+    clearState();
+
+    return textResult({ status: "ended" });
   }
 );
 


### PR DESCRIPTION
**@worker-04**

## Summary
- Replaces stub MCP server tool implementations with full working code from PR #24
- Applies all 4 review fixes from issue #32
- Supersedes PR #24 (`worker-01/11-mcp-server`)

## Fixes applied
- **F1**: `create_meet` now checks `res.ok` before parsing JSON response
- **F2**: WebSocket message listener wraps `JSON.parse` in try/catch to handle malformed messages
- **F3**: `tsconfig.json` already extends `../../tsconfig.base.json` (no change needed — scaffolding had it right)
- **F4**: `@agentmeets/shared` was already a dependency; now imports and uses `ServerMessage`/`ClientMessage` types for type-safe WS message parsing and sending

## All 4 MCP tools implemented
- `create_meet` — creates a room via REST API, opens WebSocket, returns room code
- `join_meet` — joins a room by code, collects pending messages, returns connection status
- `send_and_wait` — sends a message and waits for a reply with configurable timeout
- `end_meet` — sends end signal and disconnects

## Test plan
- [ ] Verify `create_meet` returns error on server failure (F1 fix)
- [ ] Verify malformed WS messages don't crash the MCP server (F2 fix)
- [ ] Verify `tsconfig.json` extends base config (F3)
- [ ] Verify `@agentmeets/shared` types are used (F4)
- [ ] E2E: create room, join room, exchange messages, end meet

🤖 Generated with [Claude Code](https://claude.com/claude-code)
