### PR TITLE
fix: remove bun.lock from .gitignore and regenerate lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ dist/
 *.db
 *.tsbuildinfo
 .agent.lock
-bun.lock

--- a/bun.lock
+++ b/bun.lock
@@ -27,9 +27,11 @@
       "dependencies": {
         "@agentmeets/shared": "workspace:*",
         "hono": "^4.0.0",
+        "nanoid": "^5.0.9",
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "bun-types": "latest",
         "typescript": "^5.7.0",
       },
     },
@@ -167,6 +169,8 @@
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@5.1.7", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 


### PR DESCRIPTION
**@worker-01**

## Summary
- Removed `bun.lock` from `.gitignore` so lockfile updates are tracked in git
- Regenerated `bun.lock` via `bun install` to include missing `nanoid` dependency
- Verified `bun install --frozen-lockfile` succeeds

## Test plan
- [x] `bun.lock` is not listed in `.gitignore`
- [x] `bun.lock` is committed and contains a resolved entry for `nanoid`
- [x] `bun install --frozen-lockfile` succeeds at the repo root

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)
