### PR TITLE
Fix: DATABASE_PATH, MCP publishability, and unused timeout param

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@agentmeets/mcp-server",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "main": "src/index.ts",
+  "bin": {
+    "agentmeets-mcp": "src/index.ts"
+  },
   "dependencies": {
     "@agentmeets/shared": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -114,15 +114,9 @@ const server = new McpServer({
 
 server.tool(
   "create_meet",
-  "Create a new AgentMeets room and wait for a guest to join",
-  {
-    timeout: z
-      .number()
-      .optional()
-      .default(300)
-      .describe("Seconds to wait for guest"),
-  },
-  async ({ timeout }) => {
+  "Create a new AgentMeets room. The server will keep the room open for 5 minutes waiting for a guest to join.",
+  {},
+  async () => {
     if (meetState) {
       return errorResult("A meet is already active. Call end_meet first.");
     }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,7 +5,7 @@ import type { WsData } from "./ws/index.js";
 import { roomRoutes } from "./routes/rooms.js";
 
 export function createServer(port = 3000) {
-  const db = createDatabase();
+  const db = createDatabase(process.env.DATABASE_PATH);
   const app = new Hono();
   const roomManager = new RoomManager(db);
   const wsHandlers = createWebSocketHandlers(roomManager);


### PR DESCRIPTION
**@worker-05**

## Summary
- Read `DATABASE_PATH` env var and pass it to `createDatabase()` in server
- Remove `"private": true` and add `bin` field to mcp-server `package.json` for npx publishability
- Remove unused `timeout` parameter from `create_meet` MCP tool, update description to note 5-minute server-side timeout

## Test plan
- [x] All 71 existing tests pass (`bun test`)
- [ ] Verify `DATABASE_PATH` env var is respected when starting server
- [ ] Verify `npx @agentmeets/mcp-server` works after publish
- [ ] Verify `create_meet` no longer accepts timeout parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
